### PR TITLE
LPS-77158

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/css/main.scss
@@ -5,6 +5,10 @@
 	display: none;
 }
 
+.clickDisabled {
+  pointer-events: none;
+}
+
 .portlet-document-library, .portlet-dynamic-data-mapping {
 	.field-labels-inline {
 		clear: both;

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/css/main.scss
@@ -6,7 +6,7 @@
 }
 
 .clickDisabled {
-  pointer-events: none;
+pointer-events: none;
 }
 
 .portlet-document-library, .portlet-dynamic-data-mapping {

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -59,7 +59,14 @@ AUI.add(
 
 		var DDMPortletSupport = function() {
 		};
+		
+		Liferay.on('editorRendered', function(event) {
 
+			var translationManagerId = event.portletNamespace + 'translationManager';
+
+			document.getElementById(translationManagerId).classList.remove('clickDisabled');
+		});
+		
 		DDMPortletSupport.ATTRS = {
 			doAsGroupId: {
 			},
@@ -759,7 +766,11 @@ AUI.add(
 
 						var localizationMap = instance.get('localizationMap');
 
+						var translationManagerId = instance.get('portletNamespace') + 'translationManager';
+
 						var value = instance.getValue();
+
+						document.getElementById(translationManagerId).classList.add('clickDisabled');
 
 						if (AObject.keys(localizationMap).length != 0) {
 							this.removeNotAvailableLocales(localizationMap);

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -958,6 +958,10 @@ AUI.add(
 
 						var localizationMap = {};
 
+						var translationManagerId = instance.get('portletNamespace') + 'translationManager';
+
+						document.getElementById(translationManagerId).classList.add('clickDisabled');
+						
 						if (fieldValue && fieldValue.value) {
 							localizationMap = fieldValue.value;
 						}

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -59,14 +59,7 @@ AUI.add(
 
 		var DDMPortletSupport = function() {
 		};
-		
-		Liferay.on('editorRendered', function(event) {
 
-			var translationManagerId = event.portletNamespace + 'translationManager';
-
-			document.getElementById(translationManagerId).classList.remove('clickDisabled');
-		});
-		
 		DDMPortletSupport.ATTRS = {
 			doAsGroupId: {
 			},
@@ -3034,7 +3027,8 @@ AUI.add(
 								),
 								formNode.on('submit', instance._onSubmitForm, instance),
 								Liferay.after('form:registered', instance._afterFormRegistered, instance),
-								Liferay.on('submitForm', instance._onLiferaySubmitForm, instance)
+								Liferay.on('submitForm', instance._onLiferaySubmitForm, instance),
+								Liferay.on('editorRendered', instance._onLiferayEditorRendered, instance)
 							);
 						}
 					},
@@ -3264,6 +3258,12 @@ AUI.add(
 
 							liferayForm.formValidator.set('rules', validatorRules);
 						}
+					},
+
+					_onLiferayEditorRendered: function(event) {
+						var translationManagerId = event.portletNamespace + 'translationManager';
+
+						document.getElementById(translationManagerId).classList.remove('clickDisabled');
 					},
 
 					_onLiferaySubmitForm: function(event) {

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -954,7 +954,7 @@ AUI.add(
 						var translationManagerId = instance.get('portletNamespace') + 'translationManager';
 
 						document.getElementById(translationManagerId).classList.add('clickDisabled');
-						
+
 						if (fieldValue && fieldValue.value) {
 							localizationMap = fieldValue.value;
 						}

--- a/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
@@ -353,6 +353,13 @@ name = HtmlUtil.escapeJS(name);
 		setHTML: function(value) {
 			if (alloyEditor) {
 				alloyEditor.setHTML(value);
+				
+				Liferay.fire(
+					'editorRendered',
+					{
+					portletNamespace : '<portlet:namespace />'
+					}
+				);
 			}
 		}
 	};

--- a/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
@@ -353,7 +353,7 @@ name = HtmlUtil.escapeJS(name);
 		setHTML: function(value) {
 			if (alloyEditor) {
 				alloyEditor.setHTML(value);
-				
+
 				Liferay.fire(
 					'editorRendered',
 					{

--- a/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/init.jsp
@@ -16,6 +16,8 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@

--- a/modules/apps/foundation/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -282,6 +282,13 @@ name = HtmlUtil.escapeJS(name);
 				ckEditorInstance.setData(data);
 
 				win._setStyles();
+				
+				Liferay.fire(
+					'editorRendered',
+					{
+					portletNamespace : '<portlet:namespace />'
+					}
+				);
 			};
 
 			if (win.instanceReady) {

--- a/modules/apps/foundation/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -282,7 +282,7 @@ name = HtmlUtil.escapeJS(name);
 				ckEditorInstance.setData(data);
 
 				win._setStyles();
-				
+
 				Liferay.fire(
 					'editorRendered',
 					{

--- a/modules/apps/foundation/frontend-editor/frontend-editor-simple-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-simple-web/src/main/resources/META-INF/resources/init.jsp
@@ -16,6 +16,8 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@

--- a/modules/apps/foundation/frontend-editor/frontend-editor-simple-web/src/main/resources/META-INF/resources/simple.jsp
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-simple-web/src/main/resources/META-INF/resources/simple.jsp
@@ -182,6 +182,13 @@ name = HtmlUtil.escapeJS(name);
 		setHTML: function(value) {
 			if (window['<%= name %>'].instanceReady) {
 				document.getElementById('<%= name %>').value = value || '';
+				
+				Liferay.fire(
+					'editorRendered',
+					{
+					portletNamespace : '<portlet:namespace />'
+					}
+				);
 			}
 		}
 	};

--- a/modules/apps/foundation/frontend-editor/frontend-editor-simple-web/src/main/resources/META-INF/resources/simple.jsp
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-simple-web/src/main/resources/META-INF/resources/simple.jsp
@@ -182,7 +182,7 @@ name = HtmlUtil.escapeJS(name);
 		setHTML: function(value) {
 			if (window['<%= name %>'].instanceReady) {
 				document.getElementById('<%= name %>').value = value || '';
-				
+
 				Liferay.fire(
 					'editorRendered',
 					{

--- a/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/src/main/resources/META-INF/resources/init.jsp
@@ -16,6 +16,8 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@

--- a/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/src/main/resources/META-INF/resources/tinymce.jsp
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/src/main/resources/META-INF/resources/tinymce.jsp
@@ -297,9 +297,23 @@ name = HtmlUtil.escapeJS(name);
 		setHTML: function(value) {
 			if (window['<%= name %>'].instanceReady) {
 				tinyMCE.editors['<%= name %>'].setContent(value);
+				
+				Liferay.fire(
+					'editorRendered',
+					{
+					portletNamespace : '<portlet:namespace />'
+					}
+				);
 			}
 			else {
 				document.getElementById('<%= name %>').innerHTML = value;
+				
+				Liferay.fire(
+					'editorRendered',
+					{
+					portletNamespace : '<portlet:namespace />'
+					}
+				);
 			}
 		}
 	};

--- a/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/src/main/resources/META-INF/resources/tinymce.jsp
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/src/main/resources/META-INF/resources/tinymce.jsp
@@ -297,7 +297,7 @@ name = HtmlUtil.escapeJS(name);
 		setHTML: function(value) {
 			if (window['<%= name %>'].instanceReady) {
 				tinyMCE.editors['<%= name %>'].setContent(value);
-				
+
 				Liferay.fire(
 					'editorRendered',
 					{
@@ -307,7 +307,7 @@ name = HtmlUtil.escapeJS(name);
 			}
 			else {
 				document.getElementById('<%= name %>').innerHTML = value;
-				
+
 				Liferay.fire(
 					'editorRendered',
 					{

--- a/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/src/main/resources/META-INF/resources/tinymce_simple.jsp
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/src/main/resources/META-INF/resources/tinymce_simple.jsp
@@ -246,9 +246,23 @@ name = HtmlUtil.escapeJS(name);
 		setHTML: function(value) {
 			if (window['<%= name %>'].instanceReady) {
 				tinyMCE.editors['<%= name %>'].setContent(value);
+				
+				Liferay.fire(
+					'editorRendered',
+					{
+					portletNamespace : '<portlet:namespace />'
+					}
+				);
 			}
 			else {
 				document.getElementById('<%= name %>').innerHTML = value;
+				
+				Liferay.fire(
+					'editorRendered',
+					{
+					portletNamespace : '<portlet:namespace />'
+					}
+				);
 			}
 		}
 	};

--- a/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/src/main/resources/META-INF/resources/tinymce_simple.jsp
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/src/main/resources/META-INF/resources/tinymce_simple.jsp
@@ -246,7 +246,7 @@ name = HtmlUtil.escapeJS(name);
 		setHTML: function(value) {
 			if (window['<%= name %>'].instanceReady) {
 				tinyMCE.editors['<%= name %>'].setContent(value);
-				
+
 				Liferay.fire(
 					'editorRendered',
 					{
@@ -256,7 +256,7 @@ name = HtmlUtil.escapeJS(name);
 			}
 			else {
 				document.getElementById('<%= name %>').innerHTML = value;
-				
+
 				Liferay.fire(
 					'editorRendered',
 					{


### PR DESCRIPTION
Hey @rafaprax, 

Please review this PR. Basically we are facing 2 issues where localizationMap is messed up:

1. Clicking quickly in translation manager before the editor is ready.
2. Changing among languages in translation manager.

That's the reason why the event that disable/enable the chance to click on TranslationManager is fired every time we change language.

This issue is reproducible with any editor, that's the reason why the event is triggered from all of them.

Anyway, You can find further information in LPS-77158 or just ask me (or @NemethNorbert)

Thanks.