### PR TITLE
[TECHNICAL-SUPPORT] LPS-77971

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-type-checkbox-multiple/src/main/java/com/liferay/dynamic/data/mapping/type/checkbox/multiple/internal/CheckboxMultipleDDMFormFieldValueRequestParameterRetriever.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-type-checkbox-multiple/src/main/java/com/liferay/dynamic/data/mapping/type/checkbox/multiple/internal/CheckboxMultipleDDMFormFieldValueRequestParameterRetriever.java
@@ -18,6 +18,7 @@ import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldValueRequest
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Objects;
@@ -61,8 +62,13 @@ public class CheckboxMultipleDDMFormFieldValueRequestParameterRetriever
 			return GetterUtil.DEFAULT_STRING_VALUES;
 		}
 
-		return jsonFactory.looseDeserialize(
-			defaultDDMFormFieldParameterValue, String[].class);
+		try {
+			return jsonFactory.looseDeserialize(
+				defaultDDMFormFieldParameterValue, String[].class);
+		}
+		catch (Exception e) {
+			return StringUtil.split(defaultDDMFormFieldParameterValue);
+		}
 	}
 
 	@Reference


### PR DESCRIPTION
From @austinskim123:

>NOTE: This is to fix an issue in 7.0.x, however this issue could appear for those upgrading from 7.0 to 7.1 as the non-JSON type form data would still be present in their database and would cause errors. (No Upgrade process ensures that the data will be in the JSON format after upgrading). Once this is merged, it will be backported to 7.0.x.

>Proposed fix: I placed the original return statement in a try-catch. If an exception is thrown, use StringUtil to format the predefinedValue. This way, folks who have been using predefined values in multiple checkboxes previously with quotations won't have to change it to not have quotes. At the same time, the fix will include the more intuitive method of setting predefined values for such input fields without quotations.