### PR TITLE
LPS-79418 Autosave Interval can be saved with negative integer

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	compileOnly project(":apps:portal:portal-upgrade-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
 	compileOnly project(":core:registry-api")

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/configuration/listener/DDMFormWebConfigurationModelListener.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/configuration/listener/DDMFormWebConfigurationModelListener.java
@@ -20,8 +20,11 @@ import com.liferay.portal.configuration.persistence.listener.ConfigurationModelL
 import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.Dictionary;
+import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -62,8 +65,15 @@ public class DDMFormWebConfigurationModelListener
 		throws Exception {
 
 		if (autosaveInterval < 0) {
-			throw new Exception(
-				"The autosave interval must greater than or equal to 0");
+			ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
+				"content.Language", LocaleThreadLocal.getThemeDisplayLocale(),
+				getClass());
+
+			String message = ResourceBundleUtil.getString(
+				resourceBundle,
+				"the-autosave-interval-must-be-greater-than-or-equal-to-0");
+
+			throw new Exception(message);
 		}
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/configuration/listener/DDMFormWebConfigurationModelListener.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/configuration/listener/DDMFormWebConfigurationModelListener.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.form.web.internal.configuration.listener;
+
+import com.liferay.dynamic.data.mapping.form.web.internal.configuration.DDMFormWebConfiguration;
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListener;
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+
+import java.util.Dictionary;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Drew Brokke
+ */
+@Component(
+	immediate = true,
+	property = "model.class.name=com.liferay.dynamic.data.mapping.form.web.internal.configuration.DDMFormWebConfiguration",
+	service = ConfigurationModelListener.class
+)
+public class DDMFormWebConfigurationModelListener
+	implements ConfigurationModelListener {
+
+	@Override
+	public void onBeforeSave(String pid, Dictionary<String, Object> properties)
+		throws ConfigurationModelListenerException {
+
+		DDMFormWebConfiguration ddmFormWebConfiguration =
+			ConfigurableUtil.createConfigurable(
+				DDMFormWebConfiguration.class, new HashMapDictionary<>());
+
+		try {
+			int autosaveInterval = GetterUtil.getInteger(
+				properties.get("autosaveInterval"),
+				ddmFormWebConfiguration.autosaveInterval());
+
+			_validateAutosaveInterval(autosaveInterval);
+		}
+		catch (Exception e) {
+			throw new ConfigurationModelListenerException(
+				e.getMessage(), DDMFormWebConfiguration.class, getClass(),
+				properties);
+		}
+	}
+
+	private void _validateAutosaveInterval(int autosaveInterval)
+		throws Exception {
+
+		if (autosaveInterval < 0) {
+			throw new Exception(
+				"The autosave interval must greater than or equal to 0");
+		}
+	}
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language.properties
@@ -272,6 +272,7 @@ template-key-help=The template key can be used to include this template programa
 templates-for-structure-x=Templates for Structure: {0}
 text-field-type-description=Single line or multiline text area.
 text-field-type-label=Text Field
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0.
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=The data provider cannot be deleted because it is required by one or more forms.
 the-expression-will-be-displayed-here=The expression will be displayed here.
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ar.properties
@@ -272,6 +272,7 @@ template-key-help=يمكن استخدام مفتاح القالب لتضمين �
 templates-for-structure-x=قالب الهيكل: {0}
 text-field-type-description=سطر واحد أو منطقة نص متعدد الأسطر. (Automatic Translation)
 text-field-type-label=حقل نص (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=لا يمكن حذف موفر البيانات لأنه مطلوب من قبل واحد أو أكثر من نماذج. (Automatic Translation)
 the-expression-will-be-displayed-here=سيتم عرض التعبير هنا. (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_bg.properties
@@ -272,6 +272,7 @@ template-key-help=Шаблон ключът може да се използва 
 templates-for-structure-x=Templates for Structure: {0} (Automatic Copy)
 text-field-type-description=Един ред или няколко реда текст. (Automatic Translation)
 text-field-type-label=Текстово поле (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=Доставчикът на данни не може да бъде изтрит, защото това се изисква от един или повече формуляри. (Automatic Translation)
 the-expression-will-be-displayed-here=Израз ще се покаже тук. (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ca.properties
@@ -272,6 +272,7 @@ template-key-help=La clau de la plantilla es pot utilitzar per a incloure aquest
 templates-for-structure-x=Plantilles per a l'estructura: {0}
 text-field-type-description=Una sola línia o àrea de text múltiples línies. (Automatic Translation)
 text-field-type-label=Camp de text (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=El proveïdor de dades no es pot eliminar perquè es requereix per un o més formularis.
 the-expression-will-be-displayed-here=L'expressió es mostrarà aquí.
 the-form-was-published-successfully-access-it-with-this-url-x=El formulari s'ha publicat correctament. Accedeix-hi amb aquest URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_cs.properties
@@ -272,6 +272,7 @@ template-key-help=Klíč šablony může být použit k programovému začleněn
 templates-for-structure-x=Šablony struktury {0}
 text-field-type-description=Jednom nebo víceřádkové textové oblasti. (Automatic Translation)
 text-field-type-label=Textové pole (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=Zprostředkovatel dat nelze odstranit, protože to vyžaduje jeden nebo více formulářů. (Automatic Translation)
 the-expression-will-be-displayed-here=Výraz se zobrazí zde. (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_da.properties
@@ -272,6 +272,7 @@ template-key-help=The template key can be used to include this template programa
 templates-for-structure-x=Skabeloner for struktur: {0}
 text-field-type-description=Single line or multiline text area. (Automatic Copy)
 text-field-type-label=Text Field (Automatic Copy)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=The data provider cannot be deleted because it is required by one or more forms. (Automatic Copy)
 the-expression-will-be-displayed-here=The expression will be displayed here. (Automatic Copy)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_de.properties
@@ -272,6 +272,7 @@ template-key-help=Der Vorlagenschlüssel kann benutzt werden, um diese Vorlage p
 templates-for-structure-x=Vorlagen für die Struktur: {0}
 text-field-type-description=Single line or multiline text area. (Automatic Copy)
 text-field-type-label=Text Field (Automatic Copy)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=Der Datenanbieter kann nicht gelöscht werden, da dieser für ein oder mehrere Formulare benötigt wird.
 the-expression-will-be-displayed-here=Der Ausdruck wird hier angezeigt.
 the-form-was-published-successfully-access-it-with-this-url-x=Das Formular wurde erfolgreich veröffentlicht! Greifen Sie mit dieser URL darauf zu: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_el.properties
@@ -272,6 +272,7 @@ template-key-help=Το κλειδί πρότυπο μπορεί να χρησι�
 templates-for-structure-x=Πρότυπα για τη δομή: {0}
 text-field-type-description=Ενιαία γραμμή ή περιοχή κειμένου πολλών γραμμών. (Automatic Translation)
 text-field-type-label=Πεδίο κειμένου (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=Η υπηρεσία παροχής δεδομένων δεν μπορεί να διαγραφεί, επειδή είναι που απαιτούνται από μία ή περισσότερες φόρμες. (Automatic Translation)
 the-expression-will-be-displayed-here=Η έκφραση θα εμφανιστεί εδώ. (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_en.properties
@@ -272,6 +272,7 @@ template-key-help=The template key can be used to include this template programa
 templates-for-structure-x=Templates for Structure: {0}
 text-field-type-description=Single line or multiline text area.
 text-field-type-label=Text Field
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0.
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=The data provider cannot be deleted because it is required by one or more forms.
 the-expression-will-be-displayed-here=The expression will be displayed here.
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_es.properties
@@ -272,6 +272,7 @@ template-key-help=La clave de la plantilla se puede utilizar para incluir esta p
 templates-for-structure-x=Plantillas para la estructura: {0}
 text-field-type-description=Línea o área de texto multilínea. (Automatic Translation)
 text-field-type-label=Campo de texto (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=El proveedor de datos no puede eliminarse porque se requiere en uno o más formularios
 the-expression-will-be-displayed-here=Aquí se mostrará la expresión.
 the-form-was-published-successfully-access-it-with-this-url-x=El formulario se publicó correctamente. Puede obtener acceso a este con la siguiente URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_et.properties
@@ -272,6 +272,7 @@ template-key-help=Malli võti saab lisada see mall programatically teise malli. 
 templates-for-structure-x=Templates for Structure: {0} (Automatic Copy)
 text-field-type-description=Ühel või mitmerealise teksti ala. (Automatic Translation)
 text-field-type-label=Tekstiväli (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=Andmepakkuja ei saa kustutada, kuna see nõuab ühe või mitme vormiga. (Automatic Translation)
 the-expression-will-be-displayed-here=Avaldis kuvatakse siin. (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_eu.properties
@@ -272,6 +272,7 @@ template-key-help=The template key can be used to include this template programa
 templates-for-structure-x={0} Estrukturaren Txantiloiak
 text-field-type-description=Single line or multiline text area. (Automatic Copy)
 text-field-type-label=Text Field (Automatic Copy)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=The data provider cannot be deleted because it is required by one or more forms. (Automatic Copy)
 the-expression-will-be-displayed-here=The expression will be displayed here. (Automatic Copy)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_fa.properties
@@ -272,6 +272,7 @@ template-key-help=کلید الگو را می‌تواند مورد استفاد
 templates-for-structure-x=الگوها برای ساختار: {0}
 text-field-type-description=خط یا متن چند خطی. (Automatic Translation)
 text-field-type-label=فیلد متنی (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=ایجاد کننده تاریخ قابل حذف نیست زیرا مورد نیاز تعدادی فرم است.
 the-expression-will-be-displayed-here=بیان اینجا نمایش داده خواهد شد. (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_fi.properties
@@ -272,6 +272,7 @@ template-key-help=Tätä esitysmallin avaintietoa voidaan käyttää ohjelmallis
 templates-for-structure-x=Uusi malli rakenteelle: {0}
 text-field-type-description=Single line or multiline text area. (Automatic Copy)
 text-field-type-label=Text Field (Automatic Copy)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=Tietopalvelua ei voida poistaa, koska yksi tai useampi lomake tarvitsee sitä.
 the-expression-will-be-displayed-here=Lauseke näytetään tässä.
 the-form-was-published-successfully-access-it-with-this-url-x=Lomakkeen julkaiseminen onnistui! Käyttä sitä tällä URL:lla: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_fr.properties
@@ -272,6 +272,7 @@ template-key-help=La clé du modèle peut être utilisée pour inclure ce modèl
 templates-for-structure-x=Modèles pour les structures : {0}
 text-field-type-description=Ligne unique ou une zone de texte multiligne. (Automatic Translation)
 text-field-type-label=Champ de texte (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=Le fournisseur de données ne peut pas être annulé, car il est requis par un ou plusieurs formulaires.
 the-expression-will-be-displayed-here=L'expression sera affichée ici.
 the-form-was-published-successfully-access-it-with-this-url-x=Le formulaire a bien été publié ! Accédez-y via cette URL : {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_gl.properties
@@ -272,6 +272,7 @@ template-key-help=The template key can be used to include this template programa
 templates-for-structure-x=Modelos para estrutura: {0}
 text-field-type-description=Single line or multiline text area. (Automatic Copy)
 text-field-type-label=Text Field (Automatic Copy)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=The data provider cannot be deleted because it is required by one or more forms. (Automatic Copy)
 the-expression-will-be-displayed-here=The expression will be displayed here. (Automatic Copy)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_hi_IN.properties
@@ -272,6 +272,7 @@ template-key-help=टेम्पलेट के लिए महत्वप�
 templates-for-structure-x=Templates for Structure: {0} (Automatic Copy)
 text-field-type-description=एकल पंक्ति या बहुरेखीय पाठ क्षेत्र । (Automatic Translation)
 text-field-type-label=पाठ फ़ील्ड (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=डेटा प्रदाता हटाया नहीं जा सकता क्योंकि यह एक या अधिक प्रपत्रों द्वारा आवश्यक है। (Automatic Translation)
 the-expression-will-be-displayed-here=व्यंजक यहाँ प्रदर्शित किया जाएगा। (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_hr.properties
@@ -272,6 +272,7 @@ template-key-help=The template key can be used to include this template programa
 templates-for-structure-x=Predlošci za strukturu: {0}
 text-field-type-description=Single line or multiline text area. (Automatic Copy)
 text-field-type-label=Text Field (Automatic Copy)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=The data provider cannot be deleted because it is required by one or more forms. (Automatic Copy)
 the-expression-will-be-displayed-here=The expression will be displayed here. (Automatic Copy)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_hu.properties
@@ -272,6 +272,7 @@ template-key-help=A sablon kulcs arra használható, hogy más sablonban program
 templates-for-structure-x=Sablonok a következő struktúrához: {0}
 text-field-type-description=Egysoros vagy bekezdéses szöveg terület. (Automatic Translation)
 text-field-type-label=Szöveg mező (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=Az adatszolgáltató nem törölhető, mert egy vagy több űrlaphoz szükség van rá.
 the-expression-will-be-displayed-here=A kifejezés itt fog megjelenni.
 the-form-was-published-successfully-access-it-with-this-url-x=Az űrlap közzététele sikeres volt. Elérhető a {0} URL-címen.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_in.properties
@@ -272,6 +272,7 @@ template-key-help=Tombol template dapat digunakan untuk menyertakan template ini
 templates-for-structure-x=Template untuk Struktur: {0}
 text-field-type-description=Satu baris atau area multiline teks. (Automatic Translation)
 text-field-type-label=Bidang teks (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=Penyedia data tidak dapat dihapus karena dibutuhkan oleh satu atau lebih bentuk. (Automatic Translation)
 the-expression-will-be-displayed-here=Ekspresi akan ditampilkan di sini. (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_it.properties
@@ -272,6 +272,7 @@ template-key-help=La chiave modello può essere usata per includere questo model
 templates-for-structure-x=Modello per la Struttura: {0}
 text-field-type-description=Singola linea o area di testo su più righe. (Automatic Translation)
 text-field-type-label=Campo di testo (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=Il provider dati non può essere cancellato perché richiesto da uno o più moduli.
 the-expression-will-be-displayed-here=L'espressione verrà visualizzata qui. (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_iw.properties
@@ -272,6 +272,7 @@ template-key-help=ניתן להשתמש במפתח התבנית על מנת לכ
 templates-for-structure-x=תבניות למבנה: {0}
 text-field-type-description=שורה אחת או אזור טקסט מרובת שורות. (Automatic Translation)
 text-field-type-label=שדה טקסט (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=לא ניתן למחוק את ספק הנתונים משום שהוא נדרש על ידי טופס אחד או יותר.
 the-expression-will-be-displayed-here=הביטוי יוצג כאן.
 the-form-was-published-successfully-access-it-with-this-url-x=הטופס פורסם בהצלחה! גש אליו עם כתובת URL זו: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ja.properties
@@ -272,6 +272,7 @@ template-key-help=テンプレートキーはプログラムからこのテン�
 templates-for-structure-x=ストラクチャーのテンプレート:{0}
 text-field-type-description=Single line or multiline text area. (Automatic Copy)
 text-field-type-label=Text Field (Automatic Copy)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=1つ以上のフォームに参照されているので、データプロバイダーは削除できません。
 the-expression-will-be-displayed-here=ここに式が表示されます。
 the-form-was-published-successfully-access-it-with-this-url-x=フォームは正常に公開されました。公開先URLは {0} です。

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ko.properties
@@ -272,6 +272,7 @@ template-key-help=다른 서식 파일에서이 서식 파일을 프로그래밍
 templates-for-structure-x=Templates for Structure: {0} (Automatic Copy)
 text-field-type-description=한 줄 또는 여러 줄 텍스트 영역입니다. (Automatic Translation)
 text-field-type-label=텍스트 필드 (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=데이터 공급자는 하나 이상의 양식에 필요한 때문에 삭제할 수 없습니다. (Automatic Translation)
 the-expression-will-be-displayed-here=식은 여기 표시 됩니다. (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_lo.properties
@@ -272,6 +272,7 @@ template-key-help=The template key can be used to include this template programa
 templates-for-structure-x=ແທ໋ມເພ໋ດສຳລັບໂຄງສ້າງຕ່າງໆ: {0}
 text-field-type-description=Single line or multiline text area. (Automatic Copy)
 text-field-type-label=Text Field (Automatic Copy)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=The data provider cannot be deleted because it is required by one or more forms. (Automatic Copy)
 the-expression-will-be-displayed-here=The expression will be displayed here. (Automatic Copy)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_lt.properties
@@ -272,6 +272,7 @@ template-key-help=Šablono kodą galima programatically įtraukti šį šabloną
 templates-for-structure-x=Templates for Structure: {0} (Automatic Copy)
 text-field-type-description=Vienos eilutės ir kelių eilučių teksto srityje. (Automatic Translation)
 text-field-type-label=Teksto lauke (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=Duomenų teikėjas panaikinti negalima, nes to reikalauja vieno arba kelių blankų. (Automatic Translation)
 the-expression-will-be-displayed-here=Išraiška bus rodomas čia. (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_nb.properties
@@ -272,6 +272,7 @@ template-key-help=Malnøkkelen kan brukes for å inkludere denne malen programma
 templates-for-structure-x=Maler for struktur: {0}
 text-field-type-description=Én eller flere linjer tekstområdet. (Automatic Translation)
 text-field-type-label=Tekstfelt (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=Dataleverandøren kan ikke slettes fordi det kreves av ett eller flere skjemaer. (Automatic Translation)
 the-expression-will-be-displayed-here=Uttrykket vises her. (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_nl.properties
@@ -272,6 +272,7 @@ template-key-help=De sjabloonsleutel wordt gebruikt om deze sjabloon via program
 templates-for-structure-x=Sjablonen voor structuur: {0}
 text-field-type-description=Single line or multiline text area. (Automatic Copy)
 text-field-type-label=Text Field (Automatic Copy)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=De dataprovider kan niet worden verwijderd omdat hij wordt vereist door één of meerdere formulieren.
 the-expression-will-be-displayed-here=De expressie wordt hier weergegeven.
 the-form-was-published-successfully-access-it-with-this-url-x=Het formulier is gepubliceerd en toegankelijk via deze URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_nl_BE.properties
@@ -272,6 +272,7 @@ template-key-help=De sjabloon-sleutel kan worden gebruikt om via programmacode o
 templates-for-structure-x=Sjablonen voor struktuur: {0}
 text-field-type-description=Single line or multiline text area. (Automatic Copy)
 text-field-type-label=Text Field (Automatic Copy)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=The data provider cannot be deleted because it is required by one or more forms. (Automatic Copy)
 the-expression-will-be-displayed-here=The expression will be displayed here. (Automatic Copy)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_pl.properties
@@ -272,6 +272,7 @@ template-key-help=Klucz szablonu może być użyty do programowego dołączania 
 templates-for-structure-x=Szablony dla struktury {0}
 text-field-type-description=Pojedynczy wiersz lub obszar tekstu wielowierszowego. (Automatic Translation)
 text-field-type-label=Pole tekstowe (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=Dostawca danych nie można usunąć, ponieważ jest to wymagane przez jeden lub więcej formularzy. (Automatic Translation)
 the-expression-will-be-displayed-here=Wyrażenie pojawi się tutaj. (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_pt_BR.properties
@@ -272,6 +272,7 @@ template-key-help=Esta ID do modelo pode ser usada para incluir este modelo prog
 templates-for-structure-x=Modelos para a estrutura: {0}
 text-field-type-description=Única linha ou área de texto de múltiplas linhas. (Automatic Translation)
 text-field-type-label=Campo de texto (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=O provedor de dados não pode ser excluído porque é exigido por um ou mais formulários.
 the-expression-will-be-displayed-here=A expressão será exibida aqui.
 the-form-was-published-successfully-access-it-with-this-url-x=O formulário foi publicado com sucesso. Para acessá-lo utilize esta URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_pt_PT.properties
@@ -272,6 +272,7 @@ template-key-help=A chave do template pode ser utilizada programaticamente para 
 templates-for-structure-x=Templates para a Estrutura: {0}
 text-field-type-description=Única linha ou área de texto de múltiplas linhas. (Automatic Translation)
 text-field-type-label=Campo de texto (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=O provedor de dados não pode ser excluído porque é exigido por um ou mais formulários.
 the-expression-will-be-displayed-here=A expressão será exibida aqui. (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ro.properties
@@ -272,6 +272,7 @@ template-key-help=Tasta de şablon poate fi folosit pentru a include acest şabl
 templates-for-structure-x=Templates for Structure: {0} (Automatic Copy)
 text-field-type-description=Singură linie sau zona de text cu mai multe linii. (Automatic Translation)
 text-field-type-label=Câmp de text (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=Imposibil de şters furnizorul de date, deoarece este necesar unul sau mai multe formulare. (Automatic Translation)
 the-expression-will-be-displayed-here=Expresia va fi afişată aici. (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ru.properties
@@ -272,6 +272,7 @@ template-key-help=Ключ может быть использован, для в
 templates-for-structure-x=Шаблоны для структуры: {0}
 text-field-type-description=Однострочный или многострочный текст области. (Automatic Translation)
 text-field-type-label=Текстовое поле (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=Поставщик данных нельзя удалить, поскольку он требуется один или несколько форм. (Automatic Translation)
 the-expression-will-be-displayed-here=Выражение будет отображаться здесь. (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_sk.properties
@@ -272,6 +272,7 @@ template-key-help=Kľúč šablóny môže byť použitý na programatické vnor
 templates-for-structure-x=Šablóny pre štruktúru : {0}
 text-field-type-description=Jednoriadkové alebo viacriadkové textového poľa. (Automatic Translation)
 text-field-type-label=Textové pole (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=Poskytovateľ údajov sa nedá odstrániť, pretože to vyžaduje jeden alebo viaceré formuláre. (Automatic Translation)
 the-expression-will-be-displayed-here=Tu sa zobrazí výraz. (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_sl.properties
@@ -272,6 +272,7 @@ template-key-help=Tipko predloga se lahko uporabijo za vsebujejo predlogo progra
 templates-for-structure-x=Templates for Structure: {0} (Automatic Copy)
 text-field-type-description=Ena vrstica ali območje več vrsticami besedila. (Automatic Translation)
 text-field-type-label=Polje z besedilom (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=Ponudnik podatkov ni mogoče izbrisati, ker to zahteva ena ali več oblik. (Automatic Translation)
 the-expression-will-be-displayed-here=Izraz prikaže tukaj. (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_sr_RS.properties
@@ -272,6 +272,7 @@ template-key-help=The template key can be used to include this template programa
 templates-for-structure-x=Темплејти за Структуру: {0}
 text-field-type-description=Single line or multiline text area. (Automatic Copy)
 text-field-type-label=Text Field (Automatic Copy)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=The data provider cannot be deleted because it is required by one or more forms. (Automatic Copy)
 the-expression-will-be-displayed-here=The expression will be displayed here. (Automatic Copy)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -272,6 +272,7 @@ template-key-help=The template key can be used to include this template programa
 templates-for-structure-x=Templejti za Strukturu: {0}
 text-field-type-description=Single line or multiline text area. (Automatic Copy)
 text-field-type-label=Text Field (Automatic Copy)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=The data provider cannot be deleted because it is required by one or more forms. (Automatic Copy)
 the-expression-will-be-displayed-here=The expression will be displayed here. (Automatic Copy)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_sv.properties
@@ -272,6 +272,7 @@ template-key-help=The template key can be used to include this template programa
 templates-for-structure-x=Mallar för strukturen: {0}
 text-field-type-description=Single line or multiline text area. (Automatic Copy)
 text-field-type-label=Text Field (Automatic Copy)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=The data provider cannot be deleted because it is required by one or more forms. (Automatic Copy)
 the-expression-will-be-displayed-here=The expression will be displayed here. (Automatic Copy)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_th.properties
@@ -272,6 +272,7 @@ template-key-help=คีย์ต้นแบบใช้การรวมแ�
 templates-for-structure-x=Templates for Structure: {0} (Automatic Copy)
 text-field-type-description=บรรทัดเดียวหรือพื้นที่ข้อความหลายบรรทัด (Automatic Translation)
 text-field-type-label=ฟิลด์ข้อความ (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=ให้บริการข้อมูลไม่สามารถลบได้เนื่องจากมันถูกต้องตามฟอร์มอย่าง น้อยหนึ่ง (Automatic Translation)
 the-expression-will-be-displayed-here=นิพจน์จะถูกแสดงที่นี่ (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_tr.properties
@@ -272,6 +272,7 @@ template-key-help=Şablon anahtar bu şablon olarak başka bir şablonda eklemek
 templates-for-structure-x=Templates for Structure: {0} (Automatic Copy)
 text-field-type-description=Tek satırlı veya çok satırlı metin alanı. (Automatic Translation)
 text-field-type-label=Metin alanı (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=Bir veya daha fazla form tarafından gereklidir çünkü veri sağlayıcısı silinemez. (Automatic Translation)
 the-expression-will-be-displayed-here=Ifade burada görüntülenir. (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_uk.properties
@@ -272,6 +272,7 @@ template-key-help=Шаблон ключ можна включити цей ша�
 templates-for-structure-x=Templates for Structure: {0} (Automatic Copy)
 text-field-type-description=Один рядок або область багаторядкового тексту. (Automatic Translation)
 text-field-type-label=Текстове поле (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=Постачальник даних не можна видалити, оскільки вона необхідна для однієї або кількох форм. (Automatic Translation)
 the-expression-will-be-displayed-here=Вираз буде відображено тут. (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_vi.properties
@@ -272,6 +272,7 @@ template-key-help=Khóa đặc trưng của biểu mẫu có thể sử dụng �
 templates-for-structure-x=Biểu mẫu ứng với cấu trúc: {0}
 text-field-type-description=Đường hoặc khu vực multiline text. (Automatic Translation)
 text-field-type-label=Lĩnh vực văn bản (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=Các nhà cung cấp dữ liệu không thể bị xoá vì nó là yêu cầu của một hoặc nhiều hình thức. (Automatic Translation)
 the-expression-will-be-displayed-here=Biểu thức sẽ được hiển thị ở đây. (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_zh_CN.properties
@@ -272,6 +272,7 @@ template-key-help=模板key能被程序化地用来引入在其他模板中的�
 templates-for-structure-x=结构{0}的模板
 text-field-type-description=单行或多行文本区域。 (Automatic Translation)
 text-field-type-label=文本字段 (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=数据供应商不能删除因为它需要一个或多个表格。
 the-expression-will-be-displayed-here=该表达式将显示在此处。
 the-form-was-published-successfully-access-it-with-this-url-x=表单已成功发布！使用此URL进行访问：{0}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_zh_TW.properties
@@ -272,6 +272,7 @@ template-key-help=版型鍵值能使用以程式化在其他版型包含版型�
 templates-for-structure-x=版型為結構：{0}
 text-field-type-description=單行或多行文本區域。 (Automatic Translation)
 text-field-type-label=文字欄位 (Automatic Translation)
+the-autosave-interval-must-be-greater-than-or-equal-to-0=The autosave interval must be greater than or equal to 0. (Automatic Copy)
 the-data-provider-cannot-be-deleted-because-it-is-required-by-one-or-more-forms=資料提供程式不能刪除，因為它必需的一個或多個表單。 (Automatic Translation)
 the-expression-will-be-displayed-here=該運算式將在這裡顯示。 (Automatic Translation)
 the-form-was-published-successfully-access-it-with-this-url-x=The form was published successfully! Access it with this URL: {0}


### PR DESCRIPTION
This is an update for [LPS-79418](https://issues.liferay.com/browse/LPS-79418).<br><br>Hey @rafaprax, this adds a ConfigurationModelListener class to the dynamic-data-mapping-form-web module.  It can be used in a very similar way to the ModelListener classes, so in this case it validates the autosaveInterval value before the configuration is actually saved.  If it value is negative, the listener throws an exception and the user is redirected back to the edit form.  I wanted to give this explanation because I know not many teams know about this API.  Please let me know if you have any questions.  Thanks!<br><br>/cc @pei-jung @stsquared99 @vicnate5