### PR TITLE
[TECHNICAL-SUPPORT] LPS-85177

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
@@ -26,6 +26,8 @@ AUI.add(
 
 		var LOCALIZABLE_FIELD_ATTRS = Liferay.FormBuilder.LOCALIZABLE_FIELD_ATTRS;
 
+		var RESTRICTED_NAME = 'submit';
+
 		var STR_BLANK = '';
 
 		var STR_DASH = '-';
@@ -104,6 +106,14 @@ AUI.add(
 
 		DEFAULTS_FORM_VALIDATOR.RULES.structureFieldName = function(value) {
 			return LiferayFormBuilderUtil.validateFieldName(value);
+		};
+
+		DEFAULTS_FORM_VALIDATOR.STRINGS.structureRestrictedFieldName =
+			Lang.sub(Liferay.Language.get('x-is-a-reserved-word'), [RESTRICTED_NAME]);;
+
+		DEFAULTS_FORM_VALIDATOR.RULES.structureRestrictedFieldName = function(value) {
+
+			return RESTRICTED_NAME != value;
 		};
 
 		var applyStyles = function(node, styleContent) {
@@ -1244,7 +1254,8 @@ AUI.add(
 										value: {
 											required: true,
 											structureDuplicateFieldName: true,
-											structureFieldName: true
+											structureFieldName: true,
+											structureRestrictedFieldName: true
 										}
 									}
 								}

--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -5719,6 +5719,7 @@ x-in-x={0} in {1}
 x-is={0} is...
 x-is-a-redirection-page.-it-must-be-placed-in-the-same-node-as-its-redirect-page={0} is a redirection page. It must be placed in the same node as its redirect page.
 x-is-a-required-system-role=<strong>{0}</strong> is a required system role.
+x-is-a-reserved-word={0} is a reserved word and cannot be used.
 x-is-expired={0} is expired.
 x-is-expired,-is-not-approved,-does-not-have-any-content,-or-no-longer-exists={0} is expired, is not approved, does not have any content, or no longer exists.
 x-is-not-allowed-to-join-x=<em>{0}</em> is not allowed to join <em>{1}</em>.


### PR DESCRIPTION
/cc @brianikim 

Notes from Brian:

> https://issues.liferay.com/browse/LPS-85177
> 
> The issue here is that when SPA is disabled and you try to create a Structure with a field name of "submit", the structure will not be able to be saved.
> 
> The reason for this issue is that when the field is created and you change the field name, the corresponding HTML input tag for the field changes its name to "submit".
> 
> This process causes a conflict because when Liferay tries to carry out the default submit event for the form, the input tag is instead used as the method call rather than the default javascript form.submit().
> 
> My proposed solution is to prevent users from naming the field as lower-case "submit".
> 
> I do not have the translator for the language key; I would greatly appreciate it if you could do the auto-generate portion.
> 
> Please let me know if you have any questions. Thanks.
> 
> Sincerely,
> Brian Kim