### PR TITLE
[TECHNICAL-SUPPORT] LPS-86565

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/BaseNumberDDMFormFieldValueRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/BaseNumberDDMFormFieldValueRenderer.java
@@ -18,9 +18,12 @@ import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.dynamic.data.mapping.render.BaseDDMFormFieldValueRenderer;
 import com.liferay.dynamic.data.mapping.render.ValueAccessor;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.text.NumberFormat;
+import java.text.ParseException;
 
 import java.util.Locale;
 
@@ -45,10 +48,24 @@ public abstract class BaseNumberDDMFormFieldValueRenderer
 				NumberFormat numberFormat = NumberFormat.getNumberInstance(
 					locale);
 
+				if (!valueString.equals(number.toString())) {
+					try {
+						number = numberFormat.parse(valueString);
+					}
+					catch (ParseException pe) {
+						if (_log.isWarnEnabled()) {
+							_log.warn(pe, pe);
+						}
+					}
+				}
+
 				return numberFormat.format(number);
 			}
 
 		};
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BaseNumberDDMFormFieldValueRenderer.class);
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/render/DDMFormFieldValueRendererTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/render/DDMFormFieldValueRendererTest.java
@@ -182,6 +182,25 @@ public class DDMFormFieldValueRendererTest extends BaseDDMTestCase {
 	}
 
 	@Test
+	public void testDecimalFieldValueRendererWithoutDefaultValue() {
+		DDMFormFieldValue ddmFormFieldValue = createDDMFormFieldValue(
+			"Decimal", createLocalizedValue("", "1,2", LocaleUtil.US));
+
+		DDMFormFieldValueRenderer ddmFormFieldValueRenderer =
+			new DecimalDDMFormFieldValueRenderer();
+
+		String renderedValue = ddmFormFieldValueRenderer.render(
+			ddmFormFieldValue, LocaleUtil.US);
+
+		Assert.assertEquals("0", renderedValue);
+
+		renderedValue = ddmFormFieldValueRenderer.render(
+			ddmFormFieldValue, LocaleUtil.BRAZIL);
+
+		Assert.assertEquals("1,2", renderedValue);
+	}
+
+	@Test
 	public void testDocumentLibraryFieldValueRenderer() {
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-86565

Hi @rafaprax !,

I send you this PR instead of that one: https://github.com/pedroqueiroz/liferay-portal/pull/189 that I was already talking with @pedroqueiroz about it. Please ask me any doubt that you could have.

Summarizing last PR, there were some tests that didn't work and I was researching why, because there was something weird for me. 

After some researching (and after change my PR) now  those tests are working fine and I know why didn't work before. If you see [current code](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/BaseNumberDDMFormFieldValueRenderer.java#L39-L43) (before my PR), decimal value needs to be in en_US format (or any language with a period (.) as decimal separator), even when users are using a different language than en_US, for example pt_BR. For example, I show you one use case:
- Default portal language is en_US.
- User administrator create a DDL with a field as decimal value with 2 available languages: en_US and pt_BR.
- A user add 1,2 as a decimal value in that ddl and in pt_BR (language for the ddl form, not portal language).
- In Data Base we are saving next values:
`{"en_US":"","pt_BR":"1,2"}`
So, when you try to see DDL records in widget Dynamic Data Lists Display in pt_BR (this time portal language), value will be 0 (zero), because in [this code](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/BaseNumberDDMFormFieldValueRenderer.java#L39-L43) _valueString_ will be _1,2_ and result for '_GetterUtil.getNumber(valueString);_' will be 0.

Regarding test [testDecimalFieldValueRenderer](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/render/DDMFormFieldValueRendererTest.java#L166-L182) (which failed in last PR) is the same that we update to Data Base next values:
`{"en_US":"1.2","pt_BR":"1.2"}`
You will obtain 1,2 when you portal language is pt_BR but we need to have in mind that user will not add 1.2 in pt_BR, user will try to add 1,2 (because decimal value is 1,2 in pt_BR). So, I think we need other real use case, Don't you think like that?

So I created a closer real use case in [_testDecimalFieldValueRendererWithoutDefaultValue_](https://github.com/rafaprax/liferay-portal/pull/913/files#diff-a0e5d535285ff6193300fe6a05f790ceR185), where Data Base should have next values:
`{"en_US":"","pt_BR":"1,2"}`

Does all of this make sense to you? 

The [commit](https://github.com/rafaprax/liferay-portal/pull/913/commits/51cec5b89662f3224714e531fa7cf77a010a0625) which resolve this situation just check if _valueString_ (the right value for the language) is the same that formatted 'number', if not, it is because a parse of this value is needed due to it is in a different language. I think is a better solution because I tried to don't affect rest of code, minimizing number of possible issues.

Please tell me any doubt you have and change (or ask me to change) whatever you think should be changed.

Thanks a lot!
