### PR TITLE
[TECHNICAL-SUPPORT] LPS-87176

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/DDLServiceUpgrade.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/DDLServiceUpgrade.java
@@ -23,7 +23,6 @@ import com.liferay.dynamic.data.lists.internal.upgrade.v2_0_0.util.DDLRecordSetT
 import com.liferay.dynamic.data.lists.internal.upgrade.v2_0_0.util.DDLRecordSetVersionTable;
 import com.liferay.dynamic.data.lists.internal.upgrade.v2_0_0.util.DDLRecordTable;
 import com.liferay.dynamic.data.lists.internal.upgrade.v2_0_0.util.DDLRecordVersionTable;
-import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.upgrade.BaseUpgradeSQLServerDatetime;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
@@ -62,7 +61,7 @@ public class DDLServiceUpgrade implements UpgradeStepRegistrator {
 				UpgradeDDLRecordSet(),
 			new com.liferay.dynamic.data.lists.internal.upgrade.v1_1_0.
 				UpgradeDDLRecordSetVersion(
-					_counterLocalService, _userLocalService));
+					_counterLocalService));
 
 		registry.register(
 			"1.1.0", "2.0.0",
@@ -75,8 +74,5 @@ public class DDLServiceUpgrade implements UpgradeStepRegistrator {
 
 	@Reference
 	private CounterLocalService _counterLocalService;
-
-	@Reference
-	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v1_1_0/UpgradeDDLRecordSetVersion.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v1_1_0/UpgradeDDLRecordSetVersion.java
@@ -68,12 +68,10 @@ public class UpgradeDDLRecordSetVersion extends UpgradeProcess {
 
 			try (ResultSet rs = ps1.executeQuery()) {
 				while (rs.next()) {
-					User user = _userLocalService.getUser(rs.getLong("userId"));
-
 					ps2.setLong(1, _counterLocalService.increment());
 					ps2.setLong(2, rs.getLong("groupId"));
 					ps2.setLong(3, rs.getLong("companyId"));
-					ps2.setLong(4, user.getUserId());
+					ps2.setLong(4, rs.getLong("userId"));
 					ps2.setString(5, rs.getString("userName"));
 					ps2.setTimestamp(6, rs.getTimestamp("createDate"));
 					ps2.setLong(7, rs.getLong("recordSetId"));
@@ -83,8 +81,8 @@ public class UpgradeDDLRecordSetVersion extends UpgradeProcess {
 					ps2.setString(11, rs.getString("settings_"));
 					ps2.setString(12, DDLRecordSetConstants.VERSION_DEFAULT);
 					ps2.setInt(13, WorkflowConstants.STATUS_APPROVED);
-					ps2.setLong(14, user.getUserId());
-					ps2.setString(15, user.getFullName());
+					ps2.setLong(14, rs.getLong("userId"));
+					ps2.setString(15, rs.getString("userName"));
 					ps2.setTimestamp(16, rs.getTimestamp("modifiedDate"));
 
 					ps2.addBatch();

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v1_1_0/UpgradeDDLRecordSetVersion.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v1_1_0/UpgradeDDLRecordSetVersion.java
@@ -32,11 +32,9 @@ import java.sql.ResultSet;
 public class UpgradeDDLRecordSetVersion extends UpgradeProcess {
 
 	public UpgradeDDLRecordSetVersion(
-		CounterLocalService counterLocalService,
-		UserLocalService userLocalService) {
+		CounterLocalService counterLocalService) {
 
 		_counterLocalService = counterLocalService;
-		_userLocalService = userLocalService;
 	}
 
 	@Override
@@ -94,6 +92,5 @@ public class UpgradeDDLRecordSetVersion extends UpgradeProcess {
 	}
 
 	private final CounterLocalService _counterLocalService;
-	private final UserLocalService _userLocalService;
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-87176

The issue here is when a user is deleted and any DDL they created is upgraded, the upgrade will throw a NoSuchUserException. All of the information we need from the user object already is accessable in the resultSet. The userName column in the DDLRecordSet has been [populated by (user.getFullName()](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordSetLocalServiceImpl.java#L124)) since [LPS-16106](https://issues.liferay.com/browse/LPS-16106) prior to 6.1, so I do not believe there is any need to fetch the user for data that already exists in the results of the query.