### PR TITLE
LPS-102368 Does not remove row when the index value is the same as th…

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler.js
@@ -855,7 +855,7 @@ AUI.add(
 					var weeks = DateMath.getWeeksInMonth(date, firstDayOfWeek);
 
 					A.each(instance.tableRows, function(item, index) {
-						if (index > weeks) {
+						if (index >= weeks) {
 							item.remove();
 						} else if (index < weeks && !item.parentElement) {
 							instance.tableRowContainer.appendChild(item);


### PR DESCRIPTION
/cc @knchau

Notes from Kim:
> https://issues.liferay.com/browse/LPS-102368
> Fix merged into master: https://github.com/brianchandotcom/liferay-portal/pull/79165
> 
> This fix changes the operator to include the `=`, so that an index value that is the same as the number of weeks would be removed because index starts at 0 whereas the number of week count starts at 1.
> 
> Also needs to include an update to the Alloy version when [AUI-3182](https://issues.liferay.com/browse/AUI-3182) is merged into alloy-ui master since that fix is also needed for this ticket.