### PR TITLE
LPS-106224 In Calendar If you un-check 'All Day' the start time is always hours later

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
@@ -23,10 +23,6 @@ TimeZone calendarBookingTimeZone = userTimeZone;
 
 boolean allDay = BeanParamUtil.getBoolean(calendarBooking, request, "allDay");
 
-if (allDay) {
-	calendarBookingTimeZone = utcTimeZone;
-}
-
 java.util.Calendar defaultStartTimeJCalendar = CalendarFactoryUtil.getCalendar(calendarBookingTimeZone);
 
 defaultStartTimeJCalendar.add(java.util.Calendar.HOUR, 1);

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/init.jsp
@@ -227,8 +227,6 @@ if (calendarDisplayContext != null) {
 
 TimeZone userTimeZone = TimeZone.getTimeZone(timeZoneId);
 
-TimeZone utcTimeZone = TimeZone.getTimeZone(StringPool.UTC);
-
 Format dateFormatLongDate = FastDateFormatFactoryUtil.getDate(FastDateFormatConstants.LONG, locale, userTimeZone);
 
 Format dateFormatTime = null;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-106224

I changed the steps to show the defaulted time discrepancy between the 'Add Event' button and clicking any day with 'All Day' unchecked. 

**Issue:**
In the Calendar Widget, when in the 'Month' view if you click on a day and add an event then uncheck "All Day", the default starting time of the event is set to UTC timezone even though the calendar is set to a different timezone.

**Solution:**
I removed setting "All Day" events to default to UTC timezone. This change would make the defaulted time zone match the user's/calendar's configured time zone, resulting in default hour's time to be as close to the user's current hour.