### PR TITLE
[TECHNICAL SUPPORT] LPS-107051 DDM structures with translations cannot be saved in case you add a radio or select field

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
@@ -1122,6 +1122,16 @@ AUI.add(
 			var fieldOptions = [];
 
 			if (options) {
+				var builder = instance.get('builder');
+
+				var translationManager = builder.translationManager;
+
+				var defaultLocale = translationManager.get('defaultLocale');
+
+				var availableLocales = translationManager.get(
+					'availableLocales'
+				);
+
 				options.forEach(option => {
 					var fieldOption = {};
 
@@ -1130,10 +1140,39 @@ AUI.add(
 					fieldOption.value = option.value;
 					fieldOption.label = {};
 
-					A.each(localizationMap, (item, index) => {
+					availableLocales.forEach(locale => {
+						var label = A.Object.getValue(localizationMap, [
+							locale,
+							'label'
+						]);
+
+						if (!isValue(label)) {
+							label = A.Object.getValue(localizationMap, [
+								defaultLocale,
+								'label'
+							]);
+
+							if (!isValue(label)) {
+								for (var localizationMapLocale in localizationMap) {
+									label = A.Object.getValue(localizationMap, [
+										localizationMapLocale,
+										'label'
+									]);
+
+									if (isValue(label)) {
+										break;
+									}
+								}
+							}
+
+							if (!isValue(label)) {
+								label = STR_BLANK;
+							}
+						}
+
 						fieldOption.label[
-							index
-						] = LiferayFormBuilderUtil.normalizeValue(item.label);
+							locale
+						] = LiferayFormBuilderUtil.normalizeValue(label);
 					});
 
 					fieldOptions.push(fieldOption);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
@@ -1126,8 +1126,6 @@ AUI.add(
 
 				var translationManager = builder.translationManager;
 
-				var defaultLocale = translationManager.get('defaultLocale');
-
 				var availableLocales = translationManager.get(
 					'availableLocales'
 				);
@@ -1141,34 +1139,11 @@ AUI.add(
 					fieldOption.label = {};
 
 					availableLocales.forEach(locale => {
-						var label = A.Object.getValue(localizationMap, [
+						var label = instance._getLocaleValue(
+							localizationMap,
 							locale,
 							'label'
-						]);
-
-						if (!isValue(label)) {
-							label = A.Object.getValue(localizationMap, [
-								defaultLocale,
-								'label'
-							]);
-
-							if (!isValue(label)) {
-								for (var localizationMapLocale in localizationMap) {
-									label = A.Object.getValue(localizationMap, [
-										localizationMapLocale,
-										'label'
-									]);
-
-									if (isValue(label)) {
-										break;
-									}
-								}
-							}
-
-							if (!isValue(label)) {
-								label = STR_BLANK;
-							}
-						}
+						);
 
 						fieldOption.label[
 							locale
@@ -1211,37 +1186,12 @@ AUI.add(
 
 			var translationManager = builder.translationManager;
 
-			var defaultLocale = translationManager.get('defaultLocale');
-
 			translationManager.get('availableLocales').forEach(locale => {
-				var value = A.Object.getValue(localizationMap, [
+				var value = instance._getLocaleValue(
+					localizationMap,
 					locale,
 					attribute
-				]);
-
-				if (!isValue(value)) {
-					value = A.Object.getValue(localizationMap, [
-						defaultLocale,
-						attribute
-					]);
-
-					if (!isValue(value)) {
-						for (var localizationMapLocale in localizationMap) {
-							value = A.Object.getValue(localizationMap, [
-								localizationMapLocale,
-								attribute
-							]);
-
-							if (isValue(value)) {
-								break;
-							}
-						}
-					}
-
-					if (!isValue(value)) {
-						value = STR_BLANK;
-					}
-				}
+				);
 
 				localizedValue[locale] = LiferayFormBuilderUtil.normalizeValue(
 					value
@@ -1249,6 +1199,48 @@ AUI.add(
 			});
 
 			return localizedValue;
+		};
+
+		SerializableFieldSupport.prototype._getLocaleValue = function(
+			localizationMap,
+			locale,
+			attribute
+		) {
+			var instance = this;
+
+			var builder = instance.get('builder');
+
+			var translationManager = builder.translationManager;
+
+			var defaultLocale = translationManager.get('defaultLocale');
+
+			var value = A.Object.getValue(localizationMap, [locale, attribute]);
+
+			if (!isValue(value)) {
+				value = A.Object.getValue(localizationMap, [
+					defaultLocale,
+					attribute
+				]);
+
+				if (!isValue(value)) {
+					for (var localizationMapLocale in localizationMap) {
+						value = A.Object.getValue(localizationMap, [
+							localizationMapLocale,
+							attribute
+						]);
+
+						if (isValue(value)) {
+							break;
+						}
+					}
+				}
+
+				if (!isValue(value)) {
+					value = STR_BLANK;
+				}
+			}
+
+			return value;
 		};
 
 		SerializableFieldSupport.prototype.serialize = function() {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
@@ -1216,31 +1216,31 @@ AUI.add(
 
 			var value = A.Object.getValue(localizationMap, [locale, attribute]);
 
-			if (!isValue(value)) {
+			if (isValue(value)) {
+				return value;
+			}
+
+			value = A.Object.getValue(localizationMap, [
+				defaultLocale,
+				attribute
+			]);
+
+			if (isValue(value)) {
+				return value;
+			}
+
+			for (var localizationMapLocale in localizationMap) {
 				value = A.Object.getValue(localizationMap, [
-					defaultLocale,
+					localizationMapLocale,
 					attribute
 				]);
 
-				if (!isValue(value)) {
-					for (var localizationMapLocale in localizationMap) {
-						value = A.Object.getValue(localizationMap, [
-							localizationMapLocale,
-							attribute
-						]);
-
-						if (isValue(value)) {
-							break;
-						}
-					}
-				}
-
-				if (!isValue(value)) {
-					value = STR_BLANK;
+				if (isValue(value)) {
+					return value;
 				}
 			}
 
-			return value;
+			return STR_BLANK;
 		};
 
 		SerializableFieldSupport.prototype.serialize = function() {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-107051

In order to solve this issue, in case any language is missing, I am getting the text from default one.
In the first commit https://github.com/jeyvison/liferay-portal/pull/669/commits/02d2d5ff99b83da5caac779e9826582acfcca606, I have just copied the code from here:
 - https://github.com/liferay/liferay-portal/blob/9d9fde2b59f8d50feed7ccd01519dbd8edf064a9/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js#L1177-L1205

As it is the same code in both places, I have extracted it to a new method (see commit https://github.com/jeyvison/liferay-portal/pull/669/commits/a057e125bb959d0ab60b158ec6e029eee945e923) and made some simplifications to it (see commit https://github.com/jeyvison/liferay-portal/pull/669/commits/cde9893f0ed73fa254acfc91540bdde5711d9eaf).