### PR TITLE
LPS-122477 Fix redirect after assigning workflow task to self

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/workflow_task_action.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/workflow_task_action.jsp
@@ -76,9 +76,23 @@ redirectURL.setParameter("mvcPath", "/view.jsp");
 
 			</c:when>
 			<c:otherwise>
+
+				<%
+				String workflowTaskId = liferayPortletRequest.getParameter("workflowTaskId");
+				%>
+
 				<liferay-portlet:renderURL copyCurrentRenderParameters="<%= false %>" var="assignToMeURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
 					<portlet:param name="mvcPath" value="/workflow_task_assign.jsp" />
-					<portlet:param name="redirect" value="<%= currentURL %>" />
+
+					<c:choose>
+						<c:when test="<%= Validator.isNull(workflowTaskId) %>">
+							<portlet:param name="redirect" value="<%= redirectURL.toString() %>" />
+						</c:when>
+						<c:otherwise>
+							<portlet:param name="redirect" value="<%= currentURL %>" />
+						</c:otherwise>
+					</c:choose>
+
 					<portlet:param name="workflowTaskId" value="<%= String.valueOf(workflowTask.getWorkflowTaskId()) %>" />
 					<portlet:param name="assigneeUserId" value="<%= String.valueOf(user.getUserId()) %>" />
 				</liferay-portlet:renderURL>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-122477

The issue was the page was not redirecting to the Assigned to Me tab after assigning a workflow task to self.
I fixed this issue by changing the redirect value in workflow_task_action.jsp from currentURL to redirectURL.toString().
UPDATE: I added a condition whether Assign To Me is accessed from the tasks list or from inside the task.