### PR TITLE
[Component with its own class name as service type] LPS-200284 Remove own class as service for some commerce-product-content-web classes

### DIFF
--- a/modules/apps/commerce/commerce-product-content-web/src/main/java/com/liferay/commerce/product/content/web/internal/fragment/renderer/PriceFragmentRenderer.java
+++ b/modules/apps/commerce/commerce-product-content-web/src/main/java/com/liferay/commerce/product/content/web/internal/fragment/renderer/PriceFragmentRenderer.java
@@ -5,11 +5,11 @@
 
 package com.liferay.commerce.product.content.web.internal.fragment.renderer;
 
-import com.liferay.commerce.product.content.web.internal.info.item.renderer.PriceInfoItemRenderer;
 import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.fragment.renderer.FragmentRendererContext;
 import com.liferay.info.constants.InfoDisplayWebKeys;
+import com.liferay.info.item.renderer.InfoItemRenderer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
@@ -127,7 +127,9 @@ public class PriceFragmentRenderer implements FragmentRenderer {
 	@Reference
 	private Portal _portal;
 
-	@Reference
-	private PriceInfoItemRenderer _priceInfoItemRenderer;
+	@Reference(
+		target = "(component.name=com.liferay.commerce.product.content.web.internal.info.item.renderer.PriceInfoItemRenderer)"
+	)
+	private InfoItemRenderer<CPDefinition> _priceInfoItemRenderer;
 
 }

--- a/modules/apps/commerce/commerce-product-content-web/src/main/java/com/liferay/commerce/product/content/web/internal/info/item/renderer/CPDefinitionLinkInfoItemRenderer.java
+++ b/modules/apps/commerce/commerce-product-content-web/src/main/java/com/liferay/commerce/product/content/web/internal/info/item/renderer/CPDefinitionLinkInfoItemRenderer.java
@@ -24,9 +24,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Stefano Motta
  * @author Alessio Antonio Rendina
  */
-@Component(
-	service = {CPDefinitionLinkInfoItemRenderer.class, InfoItemRenderer.class}
-)
+@Component(service = InfoItemRenderer.class)
 public class CPDefinitionLinkInfoItemRenderer
 	implements InfoItemRenderer<CPDefinition> {
 

--- a/modules/apps/commerce/commerce-product-content-web/src/main/java/com/liferay/commerce/product/content/web/internal/info/item/renderer/PriceInfoItemRenderer.java
+++ b/modules/apps/commerce/commerce-product-content-web/src/main/java/com/liferay/commerce/product/content/web/internal/info/item/renderer/PriceInfoItemRenderer.java
@@ -31,7 +31,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Alessio Antonio Rendina
  */
-@Component(service = {InfoItemRenderer.class, PriceInfoItemRenderer.class})
+@Component(service = InfoItemRenderer.class)
 public class PriceInfoItemRenderer implements InfoItemRenderer<CPDefinition> {
 
 	@Override

--- a/modules/apps/commerce/commerce-product-content-web/src/main/java/com/liferay/commerce/product/content/web/internal/info/item/renderer/ProductCardInfoItemRenderer.java
+++ b/modules/apps/commerce/commerce-product-content-web/src/main/java/com/liferay/commerce/product/content/web/internal/info/item/renderer/ProductCardInfoItemRenderer.java
@@ -32,9 +32,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Alessio Antonio Rendina
  */
-@Component(
-	service = {InfoItemRenderer.class, ProductCardInfoItemRenderer.class}
-)
+@Component(service = InfoItemRenderer.class)
 public class ProductCardInfoItemRenderer
 	implements InfoItemRenderer<CPDefinition> {
 


### PR DESCRIPTION
CPDefinitionLinkInfoItemRenderer, PriceInfoItemRenderer.java and ProductCardInfoItemRenderer were refering to their own class as an implemented service, as [pointed here](https://docs.google.com/spreadsheets/d/1y-4j4IYr7LDKDVXoOFIFvqyYgTb5t0w-iDxyyEw5OJw/edit?usp=sharing). 