### PR TITLE
[Components with more than 1 service] LPS-202191 antivirys-async-store - Splitting responsibility of AntivirusAsyncStatisticsManager

### DIFF
--- a/modules/dxp/apps/antivirus/antivirus-async-store-test/src/testIntegration/java/com/liferay/antivirus/async/store/test/AsyncAntivirusDLStoreTest.java
+++ b/modules/dxp/apps/antivirus/antivirus-async-store-test/src/testIntegration/java/com/liferay/antivirus/async/store/test/AsyncAntivirusDLStoreTest.java
@@ -56,6 +56,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import javax.management.DynamicMBean;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -69,6 +71,7 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 
 /**
@@ -462,11 +465,17 @@ public class AsyncAntivirusDLStoreTest {
 		_withAsyncAntivirusConfiguration(
 			5, "0 0/10 * * * ?", true,
 			() -> {
+				ServiceReference<?>[] references =
+					_bundleContext.getServiceReferences(
+						DynamicMBean.class.toString(),
+						"(component.name=" +
+							"com.liferay.antivirus.async.store.jmx." +
+								"AntivirusAsyncStatisticsManager)");
+
 				AntivirusAsyncStatisticsManagerMBean
 					antivirusAsyncStatisticsManagerMBean =
-						_bundleContext.getService(
-							_bundleContext.getServiceReference(
-								AntivirusAsyncStatisticsManagerMBean.class));
+						(AntivirusAsyncStatisticsManagerMBean)
+							_bundleContext.getService(references[0]);
 
 				Assert.assertNotNull(antivirusAsyncStatisticsManagerMBean);
 

--- a/modules/dxp/apps/antivirus/antivirus-async-store/src/main/java/com/liferay/antivirus/async/store/internal/event/AntivirusStatisticsUpdaterAsyncEventListener.java
+++ b/modules/dxp/apps/antivirus/antivirus-async-store/src/main/java/com/liferay/antivirus/async/store/internal/event/AntivirusStatisticsUpdaterAsyncEventListener.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.antivirus.async.store.internal.event;
+
+import com.liferay.antivirus.async.store.constants.AntivirusAsyncDestinationNames;
+import com.liferay.antivirus.async.store.event.AntivirusAsyncEvent;
+import com.liferay.antivirus.async.store.event.AntivirusAsyncEventListener;
+import com.liferay.antivirus.async.store.jmx.AntivirusStatisticsHolder;
+import com.liferay.portal.kernel.messaging.Message;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+
+/**
+ * @author Roberto Cassio Silva do Nascimento Junior
+ */
+@Component(
+	configurationPid = "com.liferay.antivirus.async.store.configuration.AntivirusAsyncConfiguration",
+	configurationPolicy = ConfigurationPolicy.REQUIRE,
+	service = AntivirusAsyncEventListener.class
+)
+public class AntivirusStatisticsUpdaterAsyncEventListener
+	implements AntivirusAsyncEventListener {
+
+	@Override
+	public void receive(Message message) {
+		AntivirusAsyncEvent antivirusAsyncEvent =
+			(AntivirusAsyncEvent)message.get("antivirusAsyncEvent");
+
+		_antivirusStatisticsHolder.onAntivirusEvent(antivirusAsyncEvent);
+	}
+
+	private final AntivirusStatisticsHolder _antivirusStatisticsHolder =
+		AntivirusStatisticsHolder.getInstance();
+
+}

--- a/modules/dxp/apps/antivirus/antivirus-async-store/src/main/java/com/liferay/antivirus/async/store/jmx/AntivirusAsyncStatisticsManager.java
+++ b/modules/dxp/apps/antivirus/antivirus-async-store/src/main/java/com/liferay/antivirus/async/store/jmx/AntivirusAsyncStatisticsManager.java
@@ -7,20 +7,16 @@ package com.liferay.antivirus.async.store.jmx;
 
 import com.liferay.antivirus.async.store.constants.AntivirusAsyncConstants;
 import com.liferay.antivirus.async.store.constants.AntivirusAsyncDestinationNames;
-import com.liferay.antivirus.async.store.event.AntivirusAsyncEvent;
-import com.liferay.antivirus.async.store.event.AntivirusAsyncEventListener;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.Destination;
 import com.liferay.portal.kernel.messaging.DestinationStatistics;
-import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerException;
 import com.liferay.portal.kernel.scheduler.StorageType;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerResponse;
 
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 
 import javax.management.DynamicMBean;
 import javax.management.NotCompliantMBeanException;
@@ -42,15 +38,10 @@ import org.osgi.service.component.annotations.Reference;
 		"jmx.objectname=com.liferay.antivirus:classification=antivirus_async,name=AntivirusAsyncStatistics",
 		"jmx.objectname.cache.key=AntivirusAsyncStatistics"
 	},
-	service = {
-		AntivirusAsyncEventListener.class,
-		AntivirusAsyncStatisticsManagerMBean.class, DynamicMBean.class
-	}
+	service = DynamicMBean.class
 )
 public class AntivirusAsyncStatisticsManager
-	extends StandardMBean
-	implements AntivirusAsyncEventListener,
-			   AntivirusAsyncStatisticsManagerMBean {
+	extends StandardMBean implements AntivirusAsyncStatisticsManagerMBean {
 
 	@Activate
 	public AntivirusAsyncStatisticsManager(
@@ -102,22 +93,22 @@ public class AntivirusAsyncStatisticsManager
 
 	@Override
 	public long getProcessingErrorCount() {
-		return _processingErrorCounter.get();
+		return _antivirusStatisticsHolder.getProcessingErrorCount();
 	}
 
 	@Override
 	public long getSizeExceededCount() {
-		return _sizeExceededCounter.get();
+		return _antivirusStatisticsHolder.getSizeExceededCount();
 	}
 
 	@Override
 	public long getTotalScannedCount() {
-		return _totalScannedCounter.get();
+		return _antivirusStatisticsHolder.getTotalScannedCount();
 	}
 
 	@Override
 	public long getVirusFoundCount() {
-		return _virusFoundCounter.get();
+		return _antivirusStatisticsHolder.getVirusFoundCount();
 	}
 
 	@Override
@@ -126,34 +117,12 @@ public class AntivirusAsyncStatisticsManager
 	}
 
 	@Override
-	public void receive(Message message) {
-		AntivirusAsyncEvent antivirusAsyncEvent =
-			(AntivirusAsyncEvent)message.get("antivirusAsyncEvent");
-
-		if (antivirusAsyncEvent == AntivirusAsyncEvent.PROCESSING_ERROR) {
-			_processingErrorCounter.incrementAndGet();
-		}
-		else if (antivirusAsyncEvent == AntivirusAsyncEvent.SIZE_EXCEEDED) {
-			_sizeExceededCounter.incrementAndGet();
-		}
-		else if (antivirusAsyncEvent == AntivirusAsyncEvent.SUCCESS) {
-			_totalScannedCounter.incrementAndGet();
-		}
-		else if (antivirusAsyncEvent == AntivirusAsyncEvent.VIRUS_FOUND) {
-			_totalScannedCounter.incrementAndGet();
-			_virusFoundCounter.incrementAndGet();
-		}
-	}
-
-	@Override
 	public void refresh() {
 		if (System.currentTimeMillis() > _lastRefresh) {
 			_destinationStatistics = _destination.getDestinationStatistics();
 			_lastRefresh = System.currentTimeMillis();
-			_processingErrorCounter.set(0);
-			_sizeExceededCounter.set(0);
-			_totalScannedCounter.set(0);
-			_virusFoundCounter.set(0);
+
+			_antivirusStatisticsHolder.reset();
 		}
 	}
 
@@ -165,17 +134,14 @@ public class AntivirusAsyncStatisticsManager
 	private static final Log _log = LogFactoryUtil.getLog(
 		AntivirusAsyncStatisticsManager.class);
 
+	private final AntivirusStatisticsHolder _antivirusStatisticsHolder =
+		AntivirusStatisticsHolder.getInstance();
 	private boolean _autoRefresh;
 	private final Destination _destination;
 	private DestinationStatistics _destinationStatistics;
 	private long _lastRefresh;
-	private final AtomicLong _processingErrorCounter = new AtomicLong();
 
 	@Reference
 	private SchedulerEngineHelper _schedulerEngineHelper;
-
-	private final AtomicLong _sizeExceededCounter = new AtomicLong();
-	private final AtomicLong _totalScannedCounter = new AtomicLong();
-	private final AtomicLong _virusFoundCounter = new AtomicLong();
 
 }

--- a/modules/dxp/apps/antivirus/antivirus-async-store/src/main/java/com/liferay/antivirus/async/store/jmx/AntivirusStatisticsHolder.java
+++ b/modules/dxp/apps/antivirus/antivirus-async-store/src/main/java/com/liferay/antivirus/async/store/jmx/AntivirusStatisticsHolder.java
@@ -1,0 +1,74 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.antivirus.async.store.jmx;
+
+import com.liferay.antivirus.async.store.event.AntivirusAsyncEvent;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * @author Roberto Cassio Silva do Nascimento Junior
+ */
+public class AntivirusStatisticsHolder {
+
+	public static AntivirusStatisticsHolder getInstance() {
+		if (_antivirusStatisticsHolder == null) {
+			_antivirusStatisticsHolder = new AntivirusStatisticsHolder();
+		}
+
+		return _antivirusStatisticsHolder;
+	}
+
+	public long getProcessingErrorCount() {
+		return _processingErrorCounter.get();
+	}
+
+	public long getSizeExceededCount() {
+		return _sizeExceededCounter.get();
+	}
+
+	public long getTotalScannedCount() {
+		return _totalScannedCounter.get();
+	}
+
+	public long getVirusFoundCount() {
+		return _virusFoundCounter.get();
+	}
+
+	public void onAntivirusEvent(AntivirusAsyncEvent antivirusAsyncEvent) {
+		if (antivirusAsyncEvent == AntivirusAsyncEvent.PROCESSING_ERROR) {
+			_processingErrorCounter.incrementAndGet();
+		}
+		else if (antivirusAsyncEvent == AntivirusAsyncEvent.SIZE_EXCEEDED) {
+			_sizeExceededCounter.incrementAndGet();
+		}
+		else if (antivirusAsyncEvent == AntivirusAsyncEvent.SUCCESS) {
+			_totalScannedCounter.incrementAndGet();
+		}
+		else if (antivirusAsyncEvent == AntivirusAsyncEvent.VIRUS_FOUND) {
+			_totalScannedCounter.incrementAndGet();
+			_virusFoundCounter.incrementAndGet();
+		}
+	}
+
+	public void reset() {
+		_processingErrorCounter.set(0);
+		_sizeExceededCounter.set(0);
+		_totalScannedCounter.set(0);
+		_virusFoundCounter.set(0);
+	}
+
+	private AntivirusStatisticsHolder() {
+	}
+
+	private static AntivirusStatisticsHolder _antivirusStatisticsHolder;
+
+	private final AtomicLong _processingErrorCounter = new AtomicLong();
+	private final AtomicLong _sizeExceededCounter = new AtomicLong();
+	private final AtomicLong _totalScannedCounter = new AtomicLong();
+	private final AtomicLong _virusFoundCounter = new AtomicLong();
+
+}


### PR DESCRIPTION
AntivirusAsyncStatisticsManager was an AntivirusAsyncEventListener and also a JMX component which allowed to view antivirus statistics through JMX visualizatian tools. With this change it now serves only JMX and there's a separate class for listening events and also for updating/providing some antivirus statistics