### PR TITLE
[Components with more than 1 service] LPS-201728 Remove ReindexSingleIndexerBackgroundTaskExecutor from BackgroundTaskConfigurator initialization

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/BackgroundTaskExecutorConfigurator.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/BackgroundTaskExecutorConfigurator.java
@@ -37,9 +37,6 @@ public class BackgroundTaskExecutorConfigurator {
 
 		_registerBackgroundTaskExecutor(
 			bundleContext, reindexPortalBackgroundTaskExecutor);
-
-		_registerBackgroundTaskExecutor(
-			bundleContext, _reindexSingleIndexerBackgroundTaskExecutor);
 	}
 
 	@Deactivate
@@ -78,10 +75,6 @@ public class BackgroundTaskExecutorConfigurator {
 
 	@Reference
 	private PortalExecutorManager _portalExecutorManager;
-
-	@Reference
-	private ReindexSingleIndexerBackgroundTaskExecutor
-		_reindexSingleIndexerBackgroundTaskExecutor;
 
 	private final Set<ServiceRegistration<BackgroundTaskExecutor>>
 		_serviceRegistrations = new HashSet<>();

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexSingleIndexerBackgroundTaskExecutor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexSingleIndexerBackgroundTaskExecutor.java
@@ -37,10 +37,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = "background.task.executor.class.name=com.liferay.portal.search.internal.background.task.ReindexSingleIndexerBackgroundTaskExecutor",
-	service = {
-		BackgroundTaskExecutor.class,
-		ReindexSingleIndexerBackgroundTaskExecutor.class
-	}
+	service = BackgroundTaskExecutor.class
 )
 public class ReindexSingleIndexerBackgroundTaskExecutor
 	extends BaseReindexBackgroundTaskExecutor {


### PR DESCRIPTION
Author: @rcsdnj
    Jira Ticket: https://liferay.atlassian.net/browse/LPS-201728
    Previous PR: https://github.com/rafaprax/liferay-portal/pull/1348

    Original PR Comment:
    >ReindexSingleIndexerBackgroundTaskExecutor had two services (ReindexSingleIndexerBackgroundTaskExecutor itself), and the only reason for this is because BackgroundTaskConfigurator was registering it manually. We removed this manual registration and consequently the need for being registered as more than 1 service. 

This change was suggested by @dantewang, in [the previous PR](https://github.com/liferay-core-infra/liferay-portal/pull/6185) refering to this task.
    