### PR TITLE
LPS-204299 [Components with more than 1 service] Lazily register IdentifiableOSGiService for FragmentEntryLinkModelListener and PLOEntryModelListener components

### DIFF
--- a/modules/apps/fragment/fragment-renderer-react-impl/build.gradle
+++ b/modules/apps/fragment/fragment-renderer-react-impl/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:fragment:fragment-api")
 	compileOnly project(":apps:frontend-js:frontend-js-loader-modules-extender-api")
 	compileOnly project(":apps:portal-template:portal-template-react-renderer-api")

--- a/modules/apps/fragment/fragment-renderer-react-impl/src/main/java/com/liferay/fragment/renderer/react/internal/model/listener/FragmentEntryLinkModelListener.java
+++ b/modules/apps/fragment/fragment-renderer-react-impl/src/main/java/com/liferay/fragment/renderer/react/internal/model/listener/FragmentEntryLinkModelListener.java
@@ -24,11 +24,15 @@ import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.module.framework.service.IdentifiableOSGiService;
 import com.liferay.portal.kernel.module.framework.service.IdentifiableOSGiServiceUtil;
+import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.MethodHandler;
 import com.liferay.portal.kernel.util.MethodKey;
 
 import java.util.List;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
@@ -36,7 +40,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Iván Zaera Avellón
  */
-@Component(service = {IdentifiableOSGiService.class, ModelListener.class})
+@Component(service = ModelListener.class)
 public class FragmentEntryLinkModelListener
 	extends BaseModelListener<FragmentEntryLink>
 	implements IdentifiableOSGiService {
@@ -95,6 +99,13 @@ public class FragmentEntryLinkModelListener
 		_fragmentEntryLinkJSModuleInitializerHelper.ensureInitialized();
 	}
 
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceRegistration = bundleContext.registerService(
+			IdentifiableOSGiService.class, this,
+			new HashMapDictionary<String, Object>());
+	}
+
 	@Deactivate
 	protected void deactivate() {
 		JSPackage jsPackage = _npmResolver.getJSPackage();
@@ -114,6 +125,10 @@ public class FragmentEntryLinkModelListener
 		}
 
 		npmRegistryUpdate.finish();
+
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
 	}
 
 	private static void _onNotify(
@@ -210,6 +225,8 @@ public class FragmentEntryLinkModelListener
 
 	@Reference
 	private NPMResolver _npmResolver;
+
+	private ServiceRegistration<IdentifiableOSGiService> _serviceRegistration;
 
 	private enum MethodType {
 


### PR DESCRIPTION
On both FragmentEntryLinkModelListener and PLOEntryModelListener components, IdentifiableOSGiService interface is being used for intracluster communcation. We moved the registering of this interface on OSGi for a later moment in the component lifecycle (at activate())